### PR TITLE
fix: poll interval to request Notion

### DIFF
--- a/src/NotionExporter.ts
+++ b/src/NotionExporter.ts
@@ -69,7 +69,7 @@ export class NotionExporter {
 
   private pollTask = (
     taskId: string,
-    pollInterval: number = 50
+    pollInterval: number = 5000
   ): Promise<string> =>
     new Promise((resolve, reject) => {
       const poll = async () => {

--- a/src/NotionExporter.ts
+++ b/src/NotionExporter.ts
@@ -69,7 +69,7 @@ export class NotionExporter {
 
   private pollTask = (
     taskId: string,
-    pollInterval: number = 5000
+    pollInterval: number = 500
   ): Promise<string> =>
     new Promise((resolve, reject) => {
       const poll = async () => {
@@ -77,7 +77,7 @@ export class NotionExporter {
         if (task.state === "success" && task.status.exportURL)
           resolve(task.status.exportURL)
         else if (task.state === "in_progress" || task.state === "not_started") {
-          setTimeout(poll, pollInterval)
+          setTimeout(poll, this.config.pollInterval || pollInterval)
         } else {
           console.error(taskId, task)
           reject(`Export task failed: ${taskId}.`)

--- a/src/NotionExporter.ts
+++ b/src/NotionExporter.ts
@@ -68,8 +68,7 @@ export class NotionExporter {
   }
 
   private pollTask = (
-    taskId: string,
-    pollInterval: number = 500
+    taskId: string
   ): Promise<string> =>
     new Promise((resolve, reject) => {
       const poll = async () => {
@@ -77,7 +76,7 @@ export class NotionExporter {
         if (task.state === "success" && task.status.exportURL)
           resolve(task.status.exportURL)
         else if (task.state === "in_progress" || task.state === "not_started") {
-          setTimeout(poll, this.config.pollInterval || pollInterval)
+          setTimeout(poll, this.config.pollInterval)
         } else {
           console.error(taskId, task)
           reject(`Export task failed: ${taskId}.`)

--- a/src/NotionExporter.ts
+++ b/src/NotionExporter.ts
@@ -14,6 +14,7 @@ interface Task {
 export class NotionExporter {
   protected readonly client: AxiosInstance
   private readonly config: Config
+  private readonly _DEFAULT_POLL_INTERVAL = 2000
 
   /**
    * Create a new NotionExporter client. To export any blocks/pages from
@@ -76,13 +77,13 @@ export class NotionExporter {
         if (task.state === "success" && task.status.exportURL)
           resolve(task.status.exportURL)
         else if (task.state === "in_progress" || task.state === "not_started") {
-          setTimeout(poll, this.config.pollInterval)
+          setTimeout(poll, this.config.pollInterval || this._DEFAULT_POLL_INTERVAL)
         } else {
           console.error(taskId, task)
           reject(`Export task failed: ${taskId}.`)
         }
       }
-      setTimeout(poll, pollInterval)
+      setTimeout(poll, this.config.pollInterval || this._DEFAULT_POLL_INTERVAL)
     })
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export interface Config {
   /** Export all blocks of the DB/page or just the ones in the current view. Default: "all" */
   collectionViewExportType?: "currentView" | "all"
   /** Poll export task finished interval in ms */
-  pollInterval: number
+  pollInterval?: number
 }
 
 export const defaultConfig: Config = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export interface Config {
   /** Export all blocks of the DB/page or just the ones in the current view. Default: "all" */
   collectionViewExportType?: "currentView" | "all"
   /** Poll export task finished interval in ms */
-  pollInterval?: number
+  pollInterval: number
 }
 
 export const defaultConfig: Config = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,5 +18,5 @@ export const defaultConfig: Config = {
   timeZone: "UTC",
   locale: "en",
   collectionViewExportType: "all",
-  pollInterval: 2000,
+  pollInterval: 500,
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,10 +10,13 @@ export interface Config {
   locale?: string
   /** Export all blocks of the DB/page or just the ones in the current view. Default: "all" */
   collectionViewExportType?: "currentView" | "all"
+  /** Poll export task finished interval in ms */
+  pollInterval?: number
 }
 
 export const defaultConfig: Config = {
   timeZone: "UTC",
   locale: "en",
   collectionViewExportType: "all",
+  pollInterval: 2000,
 }


### PR DESCRIPTION
In order to know when the export is finished, the poll interval to Notion was set to 50ms. Notion didn't bother this one (I guess they didn't pay attention ever before) but from little time ago, on this very frequent request a 429 is being received. So, as the export use to take from seconds to minutes, was tested than a value of 5000ms is ok and don't bother Notion (for now...).