### PR TITLE
fix: Support Notion v8 UUIDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "adm-zip": "^0.5.10",
         "axios": "^1.6.2",
         "sade": "^1.8.1",
-        "uuid": "^9.0.1"
+        "uuid": "11.1.0"
       },
       "bin": {
         "notion-exporter": "bin/index.js"
@@ -17015,15 +17015,15 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/uvu": {
@@ -30199,9 +30199,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
     },
     "uvu": {
       "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "adm-zip": "^0.5.10",
     "axios": "^1.6.2",
     "sade": "^1.8.1",
-    "uuid": "^9.0.1"
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.5",

--- a/src/blockId.ts
+++ b/src/blockId.ts
@@ -1,13 +1,19 @@
-import { validate } from "uuid"
 
 export const validateUuid = (str: string | undefined): string | undefined => {
-  if (!str) return undefined
-  if (validate(str)) return str
-  const withDashes = str.replace(
-    /(.{8})(.{4})(.{4})(.{4})(.+)/,
-    "$1-$2-$3-$4-$5"
-  )
-  return validate(withDashes) ? withDashes : undefined
+  if (!str) return undefined;
+
+  // Already has dashes and is UUID-ish
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(str)) {
+    return str;
+  }
+
+  // Raw 32-character hex? Let's dash it up
+  if (/^[0-9a-f]{32}$/i.test(str)) {
+    const withDashes = `${str.slice(0,8)}-${str.slice(8,12)}-${str.slice(12,16)}-${str.slice(16,20)}-${str.slice(20)}`;
+    return withDashes;
+  }
+
+  return undefined;
 }
 
 export const blockIdFromUrl = (url: string): string | undefined => {
@@ -22,5 +28,6 @@ export const blockIdFromUrl = (url: string): string | undefined => {
     return undefined
   }
   const parts = parsedUrl.pathname.slice(1).split("-")
+
   return parts[parts.length - 1]
 }

--- a/src/blockId.ts
+++ b/src/blockId.ts
@@ -1,19 +1,13 @@
+import { validate } from "uuid"
 
 export const validateUuid = (str: string | undefined): string | undefined => {
-  if (!str) return undefined;
-
-  // Already has dashes and is UUID-ish
-  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(str)) {
-    return str;
-  }
-
-  // Raw 32-character hex? Let's dash it up
-  if (/^[0-9a-f]{32}$/i.test(str)) {
-    const withDashes = `${str.slice(0,8)}-${str.slice(8,12)}-${str.slice(12,16)}-${str.slice(16,20)}-${str.slice(20)}`;
-    return withDashes;
-  }
-
-  return undefined;
+  if (!str) return undefined
+  if (validate(str)) return str
+  const withDashes = str.replace(
+    /(.{8})(.{4})(.{4})(.{4})(.+)/,
+    "$1-$2-$3-$4-$5"
+  )
+  return validate(withDashes) ? withDashes : undefined
 }
 
 export const blockIdFromUrl = (url: string): string | undefined => {
@@ -28,6 +22,5 @@ export const blockIdFromUrl = (url: string): string | undefined => {
     return undefined
   }
   const parts = parsedUrl.pathname.slice(1).split("-")
-
   return parts[parts.length - 1]
 }

--- a/test/blockId.test.ts
+++ b/test/blockId.test.ts
@@ -49,13 +49,19 @@ describe("Extract UUID from Notion URL", () => {
       "a981a0c2-68b1-35dc-bcfc-296e52ab01ec"
     )
   })
-// Notion uses non-standard UUIDs (e.g. version 8), which are valid for their API but not RFC4122
+  // Notion uses non-standard UUIDs (e.g. version 8), which are valid for their API but not RFC4122
   it("Extracts and accepts v8 UUID from a Notion.so URL", () => {
     expect(
       blockIdFromUrl(
         "https://www.notion.so/Network-Engineering-1cf62d960d7f80c79960c58edb3217fd"
       )
     ).toBe("1cf62d960d7f80c79960c58edb3217fd")
+  })
+
+  it("Validates dashed v8 UUID (Notion style)", () => {
+    expect(validateUuid("1cf62d96-0d7f-80c7-9960-c58edb3217fd")).toEqual(
+      "1cf62d96-0d7f-80c7-9960-c58edb3217fd"
+    )
   })
 
   it("Correctly extracts page UUID from notion.site URL", () => {

--- a/test/blockId.test.ts
+++ b/test/blockId.test.ts
@@ -19,6 +19,13 @@ describe("Validate UUID with and without dashes", () => {
     ).toBeUndefined()
   })
 
+  it("Validates v8 UUIDs (used by Notion)", () => {
+    // This UUID has a version 8 characters (8xxx in the third group)
+    expect(validateUuid("1cf62d960d7f80c79960c58edb3217fd")).toEqual(
+      "1cf62d96-0d7f-80c7-9960-c58edb3217fd"
+    )
+  })
+
   it("Validates without dashes", () => {
     expect(validateUuid("e0603b592edc45f7acc7b0cccd6656e1")).toEqual(
       "e0603b59-2edc-45f7-acc7-b0cccd6656e1"
@@ -41,6 +48,14 @@ describe("Extract UUID from Notion URL", () => {
     expect(blockIdFromUrl("a981a0c2-68b1-35dc-bcfc-296e52ab01ec")).toEqual(
       "a981a0c2-68b1-35dc-bcfc-296e52ab01ec"
     )
+  })
+// Notion uses non-standard UUIDs (e.g. version 8), which are valid for their API but not RFC4122
+  it("Extracts and accepts v8 UUID from a Notion.so URL", () => {
+    expect(
+      blockIdFromUrl(
+        "https://www.notion.so/Network-Engineering-1cf62d960d7f80c79960c58edb3217fd"
+      )
+    ).toBe("1cf62d960d7f80c79960c58edb3217fd")
   })
 
   it("Correctly extracts page UUID from notion.site URL", () => {


### PR DESCRIPTION
## Fix: Support Notion v8 UUIDs
This PR fixes an issue where valid Notion block IDs (e.g. version 8 UUIDs) would be rejected by the uuid.validate() check, resulting in misleading errors like:

```Invalid URL or blockId: https://www.notion.so/Whatever-1cf62d960d7f80c79960c58edb3217fd```
### The Cause
Notion block IDs look like regular UUIDs — but they can include version 8, which is outside the RFC4122 spec (1-5). For example:
Your Notion block ID might look like this:
```1cf62d96-0d7f-80c7-9960-c58edb3217fd```
That third segment is 80c7.
The uuid.validate() method from older versions didn’t recognize this as valid.

### Solution
We simply update the uuid dependency to ^11.1.0, which does validate v8 UUIDs correctly. 

Here’s the notion URL that led to this finding:
```URL: https://www.notion.so/Network-Engineering-1cf62d960d7f80c79960c58edb3217fd```

### Tests
- Added three test cases for a Notion-style v8 UUID